### PR TITLE
Fix hardcoded paths to use relative paths

### DIFF
--- a/llm_gen_code/from_pathlib_import_Path_20250105_160821.py
+++ b/llm_gen_code/from_pathlib_import_Path_20250105_160821.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 # Define the base directory
-base_dir = Path(r'C:\repo\testsite2')
+base_dir = Path.cwd() / 'repo' / 'testsite2'
 
 # Create directories
 directories = [

--- a/llm_gen_code/import_os_20250105_160759.py
+++ b/llm_gen_code/import_os_20250105_160759.py
@@ -7,7 +7,7 @@ from pathlib import Path
 def create_project():
     try:
         # Define the project directory path
-        project_path = Path(r'C:\repo\testsite2')
+        project_path = Path.cwd() / 'repo' / 'testsite2'
         
         # Create the project directory (equivalent to mkdir -p)
         project_path.mkdir(parents=True, exist_ok=True)

--- a/llm_gen_code/import_os_20250105_162712.py
+++ b/llm_gen_code/import_os_20250105_162712.py
@@ -6,7 +6,7 @@ import subprocess
 def create_project_environment():
     try:
         # Create the project directory
-        project_path = pathlib.Path(r"C:\repo\testsite2")
+        project_path = pathlib.Path.cwd() / 'repo' / 'testsite2'
         
         # Create directory if it doesn't exist
         project_path.mkdir(parents=True, exist_ok=True)

--- a/llm_gen_code/import_os_20250105_194327.py
+++ b/llm_gen_code/import_os_20250105_194327.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 # Define the base directory
-base_dir = Path("C:/repo/testsite2")
+base_dir = Path.cwd() / 'repo' / 'testsite2'
 
 # Create static subdirectories
 static_subdirs = ['css', 'js', 'images', 'uploads']

--- a/load_constants.py
+++ b/load_constants.py
@@ -27,7 +27,7 @@ JOURNAL_SYSTEM_PROMPT_FILE = JOURNAL_DIR / "journal_system_prompt.md"
 SYSTEM_PROMPT_DIR = Path(".")
 SYSTEM_PROMPT_FILE = SYSTEM_PROMPT_DIR / "system_prompt.md"
 # Add near the top with other Path definitions
-PROJECT_DIR = Path("C:/repo/")  # Default value
+PROJECT_DIR = Path.cwd()  # Default value
 
 global PROMPT_NAME
 PROMPT_NAME = None

--- a/loop_WEB.py
+++ b/loop_WEB.py
@@ -316,7 +316,7 @@ def format_messages_to_html(messages):
 def rr(strin):
     write_to_buffer(strin)
 # --- LOAD SYSTEM PROMPT ---
-with open(Path(r"C:\mygit\compuse\computer_use_demo\system_prompt.md"), 'r', encoding="utf-8") as f:
+with open(Path.cwd() / "system_prompt.md", 'r', encoding="utf-8") as f:
     SYSTEM_PROMPT = f.read()
 
 class OutputManager:

--- a/loop_gfix.py
+++ b/loop_gfix.py
@@ -229,7 +229,7 @@ def format_messages_to_string(messages):
 
 
 # --- LOAD SYSTEM PROMPT ---
-with open(Path(r"C:\mygit\compuse\computer_use_demo\system_prompt.md"), 'r', encoding="utf-8") as f:
+with open(Path.cwd() / "system_prompt.md", 'r', encoding="utf-8") as f:
     SYSTEM_PROMPT = f.read()
 
 class OutputManager:

--- a/loop_live.py
+++ b/loop_live.py
@@ -104,7 +104,7 @@ def write_to_file(s: str, file_path: str = ICECREAM_OUTPUT_FILE):
         f.write('\n' + '-' * 80 + '\n')
 ic.configureOutput(includeContext=True, outputFunction=write_to_file)
 
-with open(Path(r"C:\mygit\compuse\computer_use_demo\system_prompt.md"), 'r', encoding="utf-8") as f:
+with open(Path.cwd() / "system_prompt.md", 'r', encoding="utf-8") as f:
     SYSTEM_PROMPT = f.read()
 
 

--- a/loop_live_new.py
+++ b/loop_live_new.py
@@ -349,7 +349,7 @@ def rr(strin):
 
 # --- LOAD SYSTEM PROMPT ---
 with open(
-    Path(r"C:\mygit\compuse\computer_use_demo\system_prompt.md"), "r", encoding="utf-8"
+    CWD / "system_prompt.md", "r", encoding="utf-8"
 ) as f:
     SYSTEM_PROMPT = f.read()
 

--- a/looptemp.py
+++ b/looptemp.py
@@ -142,7 +142,7 @@ install()
 MAX_SUMMARY_MESSAGES = 40
 MAX_SUMMARY_TOKENS = 8000
 ICECREAM_OUTPUT_FILE = "debug_log.json"
-JOURNAL_FILE = r"C:\mygit\compuse\computer_use_demo\journal\journal.log"
+JOURNAL_FILE = Path.cwd() / "journal/journal.log"
 JOURNAL_ARCHIVE_FILE = "journal/journal.log.archive"
 
 HOME = Path.home()
@@ -197,7 +197,7 @@ def write_to_file(s: str, file_path: str = ICECREAM_OUTPUT_FILE):
         f.write('\n' + '-' * 80 + '\n')
 ic.configureOutput(includeContext=True, outputFunction=write_to_file)
 
-with open(Path(r"C:\mygit\compuse\computer_use_demo\system_prompt.md"), 'r', encoding="utf-8") as f:
+with open(Path.cwd() / "system_prompt.md", 'r', encoding="utf-8") as f:
     SYSTEM_PROMPT = f.read()
 
 class OutputManager:
@@ -299,7 +299,7 @@ class TokenTracker:
 JOURNAL_MODEL = "claude-3-5-haiku-latest"
 SUMMARY_MODEL = "claude-3-5-sonnet-latest"
 JOURNAL_MAX_TOKENS = 1500
-JOURNAL_SYSTEM_PROMPT_FILE = r"C:\mygit\compuse\computer_use_demo\journal\journal.log"
+JOURNAL_SYSTEM_PROMPT_FILE = Path.cwd() / "journal/journal.log"
 with open(JOURNAL_SYSTEM_PROMPT_FILE, 'r', encoding="utf-8") as f:
     JOURNAL_SYSTEM_PROMPT = f.read()
 
@@ -674,7 +674,7 @@ async def run_sampling_loop(task: str, display: AgentDisplay, output_manager: Ou
 
 async def main_async():
     """Async main function with proper error handling."""
-    prompts_dir = Path(r"C:\mygit\compuse\computer_use_demo\prompts")
+    prompts_dir = Path.cwd() / "prompts"
     prompt_files = list(prompts_dir.glob("*.md"))
 
     rr("\n[bold yellow]Available Prompts:[/bold yellow]")

--- a/tools/bash.py
+++ b/tools/bash.py
@@ -19,7 +19,7 @@ from icecream import ic
 
 ic.configureOutput(includeContext=True, outputFunction=write_to_file)
 
-PROMPT_FILE = Path(r"C:\mygit\compuse\computer_use_demo\tools\bash.md")
+PROMPT_FILE = Path.cwd() / "tools" / "bash.md"
 
 
 def read_prompt_from_file(file_path: str, bash_command: str) -> str:


### PR DESCRIPTION
Replace hardcoded absolute paths with relative paths using `Path.cwd()`.

* **llm_gen_code/from_pathlib_import_Path_20250105_160821.py**
  - Replace `C:\repo\testsite2` with `Path.cwd() / 'repo' / 'testsite2'` for `base_dir`.

* **llm_gen_code/import_os_20250105_160759.py**
  - Replace `C:\repo\testsite2` with `Path.cwd() / 'repo' / 'testsite2'` for `project_path`.

* **llm_gen_code/import_os_20250105_162712.py**
  - Replace `C:\repo\testsite2` with `Path.cwd() / 'repo' / 'testsite2'` for `project_path`.

* **llm_gen_code/import_os_20250105_194327.py**
  - Replace `C:/repo/testsite2` with `Path.cwd() / 'repo' / 'testsite2'` for `base_dir`.

* **load_constants.py**
  - Replace `C:/repo/` with `Path.cwd()` for `PROJECT_DIR`.

* **loop_gfix.py**
  - Replace `C:\mygit\compuse\computer_use_demo\system_prompt.md` with `Path.cwd() / "system_prompt.md"`.

* **loop_live_new.py**
  - Replace `C:\mygit\compuse\computer_use_demo\system_prompt.md` with `CWD / "system_prompt.md"`.

* **loop_live.py**
  - Replace `C:\mygit\compuse\computer_use_demo\system_prompt.md` with `Path.cwd() / "system_prompt.md"`.

* **loop_WEB.py**
  - Replace `C:\mygit\compuse\computer_use_demo\system_prompt.md` with `Path.cwd() / "system_prompt.md"`.

* **looptemp.py**
  - Replace `C:\mygit\compuse\computer_use_demo\system_prompt.md` with `Path.cwd() / "system_prompt.md"`.
  - Replace `C:\mygit\compuse\computer_use_demo\journal\journal.log` with `Path.cwd() / "journal/journal.log"`.
  - Replace `C:\mygit\compuse\computer_use_demo\prompts` with `Path.cwd() / "prompts"`.

* **tools/bash.py**
  - Replace `C:\mygit\compuse\computer_use_demo\tools\bash.md` with `Path.cwd() / "tools" / "bash.md"`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sambosis/BLazy/pull/3?shareId=a2634ef2-c6f7-410e-ac7f-b0e475cfd756).

## Summary by Sourcery

Chores:
- Update multiple files to use relative paths.