### PR TITLE
Replace hardcoded absolute paths with relative paths using Path.cwd()

### DIFF
--- a/load_constants.py
+++ b/load_constants.py
@@ -14,7 +14,7 @@ MAX_SUMMARY_MESSAGES = 20
 MAX_SUMMARY_TOKENS = 6000
 WORKER_DIR = Path.cwd()
 ICECREAM_OUTPUT_FILE =  WORKER_DIR / "debug_log.json"
-JOURNAL_DIR = Path("journal")
+JOURNAL_DIR = Path.cwd() / "journal"
 JOURNAL_FILE = JOURNAL_DIR / "journal.log"
 JOURNAL_ARCHIVE_FILE = JOURNAL_DIR / "journal_archive.log"
 COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
@@ -24,7 +24,7 @@ SUMMARY_MODEL = "claude-3-5-haiku-latest"
 JOURNAL_MAX_TOKENS = 4000
 MAIN_MODEL = "claude-3-5-sonnet-latest"
 JOURNAL_SYSTEM_PROMPT_FILE = JOURNAL_DIR / "journal_system_prompt.md"
-SYSTEM_PROMPT_DIR = Path(".")
+SYSTEM_PROMPT_DIR = Path.cwd()
 SYSTEM_PROMPT_FILE = SYSTEM_PROMPT_DIR / "system_prompt.md"
 # Add near the top with other Path definitions
 PROJECT_DIR = Path.cwd()  # Default value
@@ -128,6 +128,3 @@ def load_system_prompts():
     with open(paths['JOURNAL_SYSTEM_PROMPT_FILE'], 'r', encoding="utf-8") as f:
         JOURNAL_SYSTEM_PROMPT = f.read()
     return SYSTEM_PROMPT, JOURNAL_SYSTEM_PROMPT
-
-
-

--- a/loop_live.py
+++ b/loop_live.py
@@ -48,9 +48,9 @@ install()
 
 MAX_SUMMARY_MESSAGES = 40
 MAX_SUMMARY_TOKENS = 8000
-ICECREAM_OUTPUT_FILE = "debug_log.json"
-JOURNAL_FILE = r"C:\mygit\compuse\computer_use_demo\journal\journal.log"
-JOURNAL_ARCHIVE_FILE = "journal/journal.log.archive"
+ICECREAM_OUTPUT_FILE = Path.cwd() / "debug_log.json"
+JOURNAL_FILE = Path.cwd() / "journal" / "journal.log"
+JOURNAL_ARCHIVE_FILE = Path.cwd() / "journal" / "journal.log.archive"
 
 HOME = Path.home()
 PROMPT_NAME = None
@@ -190,7 +190,7 @@ class TokenTracker:
 JOURNAL_MODEL = "claude-3-5-haiku-latest"
 SUMMARY_MODEL = "claude-3-5-sonnet-latest"
 JOURNAL_MAX_TOKENS = 1500
-JOURNAL_SYSTEM_PROMPT_FILE = r"C:\mygit\compuse\computer_use_demo\journal\journal.log"
+JOURNAL_SYSTEM_PROMPT_FILE = Path.cwd() / "journal" / "journal_system_prompt.md"
 with open(JOURNAL_SYSTEM_PROMPT_FILE, 'r', encoding="utf-8") as f:
     JOURNAL_SYSTEM_PROMPT = f.read()
 


### PR DESCRIPTION
Replace hardcoded absolute paths with relative paths using `Path.cwd()`.

* **load_constants.py**
  - Replace hardcoded absolute paths with `Path.cwd()` to make paths relative.
  - Update constants to use relative paths.

* **loop_live.py**
  - Replace hardcoded absolute paths with `Path.cwd()` to make paths relative.
  - Update file paths in functions to use relative paths.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sambosis/BLazy/pull/4?shareId=4e0e53d6-5ad1-4945-8364-a65be74c76b7).

## Summary by Sourcery

Enhancements:
- Use relative paths for files in the "journal" directory and other configuration files.